### PR TITLE
Moved from sha to ref for release naming

### DIFF
--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -44,8 +44,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.sha }}
-          release_name: 'Release ${{ github.sha }}'
+          tag_name: ${{ github.ref }}
+          release_name: 'Release ${{ github.ref }}'
           body: ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: false


### PR DESCRIPTION
- Use Github.ref rather than sha for naming the release.